### PR TITLE
fix(export): différencie les noms des fichiers envoyés avec une pec ou un avis pour éviter un écrasement

### DIFF
--- a/src/Command/AbstractExportCommand.php
+++ b/src/Command/AbstractExportCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\PlatauPiece;
+use App\Service\Prevarisc as PrevariscService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractExportCommand extends Command
+{
+    protected PrevariscService $prevarisc_service;
+    protected PlatauPiece $piece_service;
+
+    public function __construct(PrevariscService $prevarisc_service, PlatauPiece $piece_service)
+    {
+        $this->prevarisc_service = $prevarisc_service;
+        $this->piece_service     = $piece_service;
+        parent::__construct();
+    }
+
+    /**
+     * Upload les pièces jointes en attente d'un dossier vers Syncplicity.
+     *
+     * Le nom de fichier sur Syncplicity est construit comme "{NOM}_{ID}.ext" afin de
+     * garantir un data_file_id unique par pièce jointe et d'éviter les collisions quand
+     * plusieurs consultations partagent le même nom de fichier original.
+     *
+     * @param int $type_document Nomenclature TYPE_DOCUMENT Plat'AU (ex. 9 = avis, 47 = PEC)
+     *
+     * @return array{pieces: list<array<string, mixed>>, pieces_to_export: list<array<string, mixed>>}
+     */
+    protected function uploaderPiecesJointes(int $dossier_id, int $type_document, OutputInterface $output) : array
+    {
+        $pieces           = [];
+        $pieces_to_export = [];
+
+        if (!$this->piece_service->getSyncplicity()) {
+            return compact('pieces', 'pieces_to_export');
+        }
+
+        $pieces_to_export = $this->prevarisc_service->recupererPiecesAvecStatut($dossier_id, 'to_be_exported');
+
+        foreach ($pieces_to_export as $piece_jointe) {
+            $filename             = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
+            $syncplicity_filename = $piece_jointe['NOM_PIECEJOINTE'].'_'.$piece_jointe['ID_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
+            $contents             = $this->prevarisc_service->recupererFichierPhysique($output, $piece_jointe['ID_PIECEJOINTE'], $piece_jointe['EXTENSION_PIECEJOINTE']);
+
+            if (null === $contents) {
+                $output->writeln(\sprintf('Impossible de récupérer le contenu du fichier %s', $filename));
+                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');
+                $this->prevarisc_service->ajouterMessageErreurPiece($piece_jointe['ID_PIECEJOINTE'], 'Impossible de récupérer le contenu du fichier');
+
+                continue;
+            }
+
+            try {
+                $pieces[] = $this->piece_service->uploadDocument($syncplicity_filename, $contents, $type_document);
+                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'awaiting_status');
+            } catch (\Exception $e) {
+                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');
+                $this->prevarisc_service->ajouterMessageErreurPiece($piece_jointe['ID_PIECEJOINTE'], $e->getMessage());
+            }
+        }
+
+        return compact('pieces', 'pieces_to_export');
+    }
+}

--- a/src/Command/ExportAvis.php
+++ b/src/Command/ExportAvis.php
@@ -117,7 +117,13 @@ final class ExportAvis extends Command
                         $pieces_to_export = $this->prevarisc_service->recupererPiecesAvecStatut($dossier['ID_DOSSIER'], 'to_be_exported');
 
                         foreach ($pieces_to_export as $piece_jointe) {
-                            $filename = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
+                            $filename            = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
+                            // Le nom utilisé sur Syncplicity doit être unique par pièce jointe pour éviter
+                            // l'écrasement : Syncplicity réutilise le même data_file_id pour un même nom de
+                            // fichier dans le même dossier virtuel. Sans unicité, Plat'AU récupère toujours
+                            // la dernière version uploadée, causant des erreurs de hash (code 10) ou de
+                            // fichier introuvable (code 9) pour toutes les consultations sauf la dernière.
+                            $syncplicity_filename = $piece_jointe['NOM_PIECEJOINTE'].'_'.$piece_jointe['ID_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
                             $contents = $this->prevarisc_service->recupererFichierPhysique($output, $piece_jointe['ID_PIECEJOINTE'], $piece_jointe['EXTENSION_PIECEJOINTE']);
 
                             if (null === $contents) {
@@ -129,7 +135,7 @@ final class ExportAvis extends Command
                             }
 
                             try {
-                                $pieces[] = $this->piece_service->uploadDocument($filename, $contents, 9); // Type document 9 = Document lié à un avis
+                                $pieces[] = $this->piece_service->uploadDocument($syncplicity_filename, $contents, 9); // Type document 9 = Document lié à un avis
                                 $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'awaiting_status');
                             } catch (\Exception $e) {
                                 $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');

--- a/src/Command/ExportAvis.php
+++ b/src/Command/ExportAvis.php
@@ -13,11 +13,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use App\Service\PlatauConsultation as PlatauConsultationService;
 
-final class ExportAvis extends Command
+final class ExportAvis extends AbstractExportCommand
 {
-    private PrevariscService $prevarisc_service;
     private PlatauConsultationService $consultation_service;
-    private PlatauPiece $piece_service;
     private PlatauAvis $avis_service;
     private DateParser $date_parser;
 
@@ -26,12 +24,10 @@ final class ExportAvis extends Command
      */
     public function __construct(PrevariscService $prevarisc_service, PlatauConsultationService $consultation_service, PlatauPiece $piece_service, PlatauAvis $avis_service, DateParser $date_parser)
     {
-        $this->prevarisc_service    = $prevarisc_service;
+        parent::__construct($prevarisc_service, $piece_service);
         $this->consultation_service = $consultation_service;
-        $this->piece_service        = $piece_service;
         $this->avis_service         = $avis_service;
         $this->date_parser          = $date_parser;
-        parent::__construct();
     }
 
     /**
@@ -113,36 +109,7 @@ final class ExportAvis extends Command
                     $prescriptions = $this->prevarisc_service->getPrescriptions($dossier['ID_DOSSIER']);
 
                     // On recherche les pièces jointes en attente d'envoi vers Plat'AU associées au dossier Prevarisc
-                    if ($this->piece_service->getSyncplicity()) {
-                        $pieces_to_export = $this->prevarisc_service->recupererPiecesAvecStatut($dossier['ID_DOSSIER'], 'to_be_exported');
-
-                        foreach ($pieces_to_export as $piece_jointe) {
-                            $filename            = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
-                            // Le nom utilisé sur Syncplicity doit être unique par pièce jointe pour éviter
-                            // l'écrasement : Syncplicity réutilise le même data_file_id pour un même nom de
-                            // fichier dans le même dossier virtuel. Sans unicité, Plat'AU récupère toujours
-                            // la dernière version uploadée, causant des erreurs de hash (code 10) ou de
-                            // fichier introuvable (code 9) pour toutes les consultations sauf la dernière.
-                            $syncplicity_filename = $piece_jointe['NOM_PIECEJOINTE'].'_'.$piece_jointe['ID_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
-                            $contents = $this->prevarisc_service->recupererFichierPhysique($output, $piece_jointe['ID_PIECEJOINTE'], $piece_jointe['EXTENSION_PIECEJOINTE']);
-
-                            if (null === $contents) {
-                                $output->writeln(\sprintf('Impossible de récupérer le contenu du fichier %s', $filename));
-                                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');
-                                $this->prevarisc_service->ajouterMessageErreurPiece($piece_jointe['ID_PIECEJOINTE'], 'Impossible de récupérer le contenu du fichier');
-
-                                continue;
-                            }
-
-                            try {
-                                $pieces[] = $this->piece_service->uploadDocument($syncplicity_filename, $contents, 9); // Type document 9 = Document lié à un avis
-                                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'awaiting_status');
-                            } catch (\Exception $e) {
-                                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');
-                                $this->prevarisc_service->ajouterMessageErreurPiece($piece_jointe['ID_PIECEJOINTE'], $e->getMessage());
-                            }
-                        }
-                    }
+                    ['pieces' => $pieces, 'pieces_to_export' => $pieces_to_export] = $this->uploaderPiecesJointes($dossier['ID_DOSSIER'], 9, $output);
 
                     // On verse l'avis de commission Prevarisc (défavorable, favorable ou sans avis) dans Plat'AU
                     $avis_dossier_commission = $dossier['AVIS_DOSSIER_COMMISSION'];

--- a/src/Command/ExportPEC.php
+++ b/src/Command/ExportPEC.php
@@ -12,11 +12,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use App\Service\PlatauConsultation as PlatauConsultationService;
 
-final class ExportPEC extends Command
+final class ExportPEC extends AbstractExportCommand
 {
-    private PrevariscService $prevarisc_service;
     private PlatauConsultationService $consultation_service;
-    private PlatauPiece $piece_service;
     private DateParser $date_parser;
 
     /**
@@ -24,11 +22,9 @@ final class ExportPEC extends Command
      */
     public function __construct(PrevariscService $prevarisc_service, PlatauConsultationService $consultation_service, PlatauPiece $piece_service, DateParser $date_parser)
     {
-        $this->prevarisc_service    = $prevarisc_service;
+        parent::__construct($prevarisc_service, $piece_service);
         $this->consultation_service = $consultation_service;
-        $this->piece_service        = $piece_service;
         $this->date_parser          = $date_parser;
-        parent::__construct();
     }
 
     /**
@@ -98,31 +94,7 @@ final class ExportPEC extends Command
                     }
 
                     // On recherche les pièces jointes en attente d'envoi vers Plat'AU associées au dossier Prevarisc
-                    if ($this->piece_service->getSyncplicity()) {
-                        $pieces_to_export = $this->prevarisc_service->recupererPiecesAvecStatut($dossier['ID_DOSSIER'], 'to_be_exported');
-
-                        foreach ($pieces_to_export as $piece_jointe) {
-                            $filename             = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
-                            $syncplicity_filename = $piece_jointe['NOM_PIECEJOINTE'].'_'.$piece_jointe['ID_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
-                            $contents = $this->prevarisc_service->recupererFichierPhysique($output, $piece_jointe['ID_PIECEJOINTE'], $piece_jointe['EXTENSION_PIECEJOINTE']);
-
-                            if (null === $contents) {
-                                $output->writeln(\sprintf('Impossible de récupérer le contenu du fichier %s', $filename));
-                                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');
-                                $this->prevarisc_service->ajouterMessageErreurPiece($piece_jointe['ID_PIECEJOINTE'], 'Impossible de récupérer le contenu du fichier');
-
-                                continue;
-                            }
-
-                            try {
-                                $pieces[] = $this->piece_service->uploadDocument($syncplicity_filename, $contents, 47); // Type document 47 = Document lié à une prise en compte métier
-                                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'awaiting_status');
-                            } catch (\Exception $e) {
-                                $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');
-                                $this->prevarisc_service->ajouterMessageErreurPiece($piece_jointe['ID_PIECEJOINTE'], $e->getMessage());
-                            }
-                        }
-                    }
+                    ['pieces' => $pieces, 'pieces_to_export' => $pieces_to_export] = $this->uploaderPiecesJointes($dossier['ID_DOSSIER'], 47, $output);
 
                     // Si le dossier est déclaré incomplet, on envoie une PEC négative
                     if ('1' === (string) $dossier['INCOMPLET_DOSSIER']) {

--- a/src/Command/ExportPEC.php
+++ b/src/Command/ExportPEC.php
@@ -102,7 +102,8 @@ final class ExportPEC extends Command
                         $pieces_to_export = $this->prevarisc_service->recupererPiecesAvecStatut($dossier['ID_DOSSIER'], 'to_be_exported');
 
                         foreach ($pieces_to_export as $piece_jointe) {
-                            $filename = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
+                            $filename             = $piece_jointe['NOM_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
+                            $syncplicity_filename = $piece_jointe['NOM_PIECEJOINTE'].'_'.$piece_jointe['ID_PIECEJOINTE'].$piece_jointe['EXTENSION_PIECEJOINTE'];
                             $contents = $this->prevarisc_service->recupererFichierPhysique($output, $piece_jointe['ID_PIECEJOINTE'], $piece_jointe['EXTENSION_PIECEJOINTE']);
 
                             if (null === $contents) {
@@ -114,7 +115,7 @@ final class ExportPEC extends Command
                             }
 
                             try {
-                                $pieces[] = $this->piece_service->uploadDocument($filename, $contents, 47); // Type document 47 = Document lié à une prise en compte métier
+                                $pieces[] = $this->piece_service->uploadDocument($syncplicity_filename, $contents, 47); // Type document 47 = Document lié à une prise en compte métier
                                 $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'awaiting_status');
                             } catch (\Exception $e) {
                                 $this->prevarisc_service->changerStatutPiece($piece_jointe['ID_PIECEJOINTE'], 'on_error');

--- a/src/Service/PlatauPiece.php
+++ b/src/Service/PlatauPiece.php
@@ -27,7 +27,6 @@ final class PlatauPiece extends PlatauAbstract
         $syncplicity_folder_id = (string) $file['VirtualFolderId'];
 
         $hash_sha512 = hash('sha512', $file_contents);
-        error_log(\sprintf('[PLATAU_HASH_DEBUG] Fichier "%s" uploadé : taille=%d octets, sha256_syncplicity=%s, sha512_platau=%s', $filename, strlen($file_contents), hash('sha256', $file_contents), $hash_sha512));
 
         $document = [
             'fileId' => $syncplicity_file_id,

--- a/src/Service/PlatauPiece.php
+++ b/src/Service/PlatauPiece.php
@@ -26,13 +26,16 @@ final class PlatauPiece extends PlatauAbstract
         \assert(\array_key_exists('VirtualFolderId', $file));
         $syncplicity_folder_id = (string) $file['VirtualFolderId'];
 
+        $hash_sha512 = hash('sha512', $file_contents);
+        error_log(\sprintf('[PLATAU_HASH_DEBUG] Fichier "%s" uploadé : taille=%d octets, sha256_syncplicity=%s, sha512_platau=%s', $filename, strlen($file_contents), hash('sha256', $file_contents), $hash_sha512));
+
         $document = [
             'fileId' => $syncplicity_file_id,
             'folderId' => $syncplicity_folder_id,
             'dtProduction' => (new \DateTime())->format('Y-m-d'),
             'idActeurProducteur' => (string) $this->getConfig()['PLATAU_ID_ACTEUR_APPELANT'],
             'algoHash' => 'SHA-512',
-            'hash' => hash('sha512', $file_contents),
+            'hash' => $hash_sha512,
             'nomTypeDocument' => $type_document,  // Nomenclature TYPE_DOCUMENT
             'nomTypeProducteurDoc' => 1,  // Nomenclature NATURE_PIECE. Toujours à 1 : "Personne jouant un rôle dans un dossier"
         ];

--- a/src/Service/Prevarisc.php
+++ b/src/Service/Prevarisc.php
@@ -540,8 +540,6 @@ class Prevarisc
         try {
             $contents = $this->filesystem->read($filepath);
 
-            $output->writeln(\sprintf('[HASH_DEBUG] Fichier %s lu depuis le filesystem : taille=%d octets, sha512=%s', $filepath, strlen($contents), hash('sha512', $contents)));
-
             /**
              * Copie temporaire en local du fichier.
              * Permet de stabiliser la lecture d'un fichier depuis un filesystem Windows
@@ -574,8 +572,6 @@ class Prevarisc
 
                 return null;
             }
-
-            $output->writeln(\sprintf('[HASH_DEBUG] Fichier %s après copie locale : taille=%d octets, sha512=%s', $filepath, strlen($stable_contents), hash('sha512', $stable_contents)));
 
             return $stable_contents;
         } catch (Flysystem\FilesystemException $filesystemException) {

--- a/src/Service/Prevarisc.php
+++ b/src/Service/Prevarisc.php
@@ -540,6 +540,8 @@ class Prevarisc
         try {
             $contents = $this->filesystem->read($filepath);
 
+            $output->writeln(\sprintf('[HASH_DEBUG] Fichier %s lu depuis le filesystem : taille=%d octets, sha512=%s', $filepath, strlen($contents), hash('sha512', $contents)));
+
             /**
              * Copie temporaire en local du fichier.
              * Permet de stabiliser la lecture d'un fichier depuis un filesystem Windows
@@ -572,6 +574,8 @@ class Prevarisc
 
                 return null;
             }
+
+            $output->writeln(\sprintf('[HASH_DEBUG] Fichier %s après copie locale : taille=%d octets, sha512=%s', $filepath, strlen($stable_contents), hash('sha512', $stable_contents)));
 
             return $stable_contents;
         } catch (Flysystem\FilesystemException $filesystemException) {


### PR DESCRIPTION
Mise en draft en attente de confirmation par le SDIS 85 : test avec fichiers nommés différemment